### PR TITLE
Make ndradexhyperfine explicitly optional

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ Changelog
 0.3 (Unreleased)
 ================
 
+* Update tutorials since some functions have changed
+* Explicitly make ndradexhyperfine optional
 * Added pure Gaussian option, which just models purely Gaussian line profiles with Tpeak/v/sigma
 * Fix bug in map making if ``fit_type`` is not ``lte``
 * Increased default sigma bound to 500, to better capture velocity dispersion on larger

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -11,12 +11,15 @@ McFine requires:
 * astropy
 * emcee
 * lmfit
-* ndradexhyperfine
 * numdifftools
 * numpy
 * scipy
 * threadpoolctl
 * tqdm
+
+The RT mode requires:
+
+* ndradexhyperfine
 
 The plotting requires:
 

--- a/docs/tutorials/generating_a_spectrum.rst
+++ b/docs/tutorials/generating_a_spectrum.rst
@@ -8,6 +8,7 @@ This is how you can generate an N2H+ spectrum (which here is centred around a ve
 .. code-block:: python
 
     import matplotlib.pyplot as plt
+    from mcfine.fitting import multiple_components
     from mcfine.line_info import v_lines, strength_lines
     import numpy as np
 
@@ -55,7 +56,13 @@ This is how you can generate an N2H+ spectrum (which here is centred around a ve
 
     # Generate noise-free spectrum
     props = ['tex', 'tau', 'v', 'sigma']
-    spectrum_noise_free = multiple_components(theta, vel, strength_lines, v_lines, props, n_comp)
+    spectrum_noise_free = multiple_components(theta=theta,
+                                              vel=vel,
+                                              strength_lines=strength_lines_n2hp,
+                                              v_lines=v_lines_n2hp,
+                                              props=props,
+                                              n_comp=n_comp,
+                                              )
 
     # Create an error spectrum with 0.1K random noise and 5% calibration error
     noise_level = 0.1

--- a/mcfine/fitting.py
+++ b/mcfine/fitting.py
@@ -16,7 +16,14 @@ except ModuleNotFoundError:
 
 import astropy.units as u
 import emcee
-import ndradexhyperfine as ndradex
+
+NDRADEX_IMPORTED = False
+try:
+    import ndradexhyperfine as ndradex
+    NDRADEX_IMPORTED = True
+except ModuleNotFoundError:
+    pass
+
 import numpy as np
 from lmfit import minimize, Parameters
 from scipy.interpolate import RegularGridInterpolator
@@ -685,6 +692,10 @@ class HyperfineFitter:
                             )
         self.logger = logging.getLogger(__name__)
 
+        # Let us know if ndradex has been imported
+        if not NDRADEX_IMPORTED:
+            self.logger.warning("ndradexhyperfine not imported. RT capabilities disabled")
+
         if data is None:
             self.logger.warning('data should be provided!')
             sys.exit()
@@ -736,6 +747,9 @@ class HyperfineFitter:
             sys.exit()
 
         self.fit_type = fit_type
+
+        if self.fit_type == "radex" and not NDRADEX_IMPORTED:
+            raise ValueError("Cannot use mode radex if ndradexhyperfine is not installed!")
 
         fit_method = get_dict_val(self.config,
                                   self.config_defaults,


### PR DESCRIPTION
- Makes ndradex optional (since the pip installation doesn't explicitly require it)
- Updates docs so they actually work