### PR TITLE
Update fit philosophy

### DIFF
--- a/docs/advanced_topics.rst
+++ b/docs/advanced_topics.rst
@@ -75,7 +75,7 @@ this will use another few parameters:
 .. code-block:: toml
 
    [mcmc]
-   convergence_factor = 100
+   convergence_factor = 10
    tau_change = 0.01
    thin = 0.5
    burn_in = 2
@@ -86,8 +86,8 @@ is ``convergence_factor`` times the autocorrelation length, and the change in th
 by less than a factor of ``tau_change``. To ensure the MCMC doesn't run forever, the maximum number
 of steps is ``max_steps``.
 
-After this, we then use ``thin`` and ``burn_in`` to control how the sampler is pared down for parameter
-estimation. We use a factor of ``burn_in`` time the autocorrelation length to define the burn-in, and then
+After this, for both methods we then use ``thin`` and ``burn_in`` to control how the sampler is pared down for
+parameter estimation. We use a factor of ``burn_in`` time the autocorrelation length to define the burn-in, and then
 thin by a factor of ``thin`` times the autocorrelation length to thin out the chains. For more details on
 these, see the `emcee docs <https://emcee.readthedocs.io/en/stable/tutorials/monitor/>`_.
 

--- a/docs/fitting_philosophy.rst
+++ b/docs/fitting_philosophy.rst
@@ -1,0 +1,57 @@
+##################
+Fitting Philosophy
+##################
+
+``mcfine`` operates by default in a two-step manner. Firstly, it will try and find an initial solution
+using ``lmfit`` (The Initial Fit), before exploring the parameter space more thoroughly using ``emcee``
+(The MCMC Fit).
+
+===============
+The Initial Fit
+===============
+
+Getting a good initial guess is critical for this fitting. ``mcfine`` offers two methods that have similar
+accuracy, but different performance. Both of these wrap around ``lmfit``, which provides least-squares minimization.
+
+-------
+default
+-------
+
+The default method simply tries to fit the spectrum with the number of components supplied. For high-dimensions,
+the solver is critical. We recommend ``basinhopping``, which is slow but reliable. This is a "global" minimization
+strategy that works well in high dimensions, but is **very slow**. For instance, running this on a 5-parameter
+model can take upwards of 5 minutes. As such, when speed is not critical this is probably the optimal choice,
+but for large datasets can slow things down significantly.
+
+---------
+iterative
+---------
+
+Alternatively, to try and sidestep the issue of slow fits in high dimensions, we offer an ``iterative`` method, which
+instead uses derivative spectroscopy to estimate where lines are, before fitting them and subtracting them off to
+try and find the position of the next line (this is the iterative part). As the complexity increases, the components
+are fit simultaneously to try and avoid degeneracies. Because this means the initial velocity guess is better, this
+tends to be better behaved and so a faster least-square minimizer can be used. This means this method scales
+significantly better than the default with basinhopping - around three times faster. Here, we recommend the ``powell``
+minimizer, which works well with noisy data.
+
+============
+The MCMC Fit
+============
+
+Having got initial parameters from ``lmfit``, we now move onto the thing that sets ``mcfine`` apart: the MCMC fitting.
+We again take an iterative approach here, performing a number of "burn-in" runs (the number is configurable, but two
+seems to work well) where we distribute the MCMC walkers around the maximum likelihood solution (this either comes
+from ``lmfit`` or a previous MCMC burn-in run). These are distributed normally, with a standard deviation of 1% of
+the value for the first initialisation run, and then a much tighter ball for subsequent runs. We then run for either
+a fixed number of iterations (``fixed``) or an adaptive number where the autocorrelation time is used to decide when
+to stop (``adaptive``). The fixed method is generally much faster, but may produce suboptimal results (particularly at
+high complexity). We recommend users experiment to see what works best for them.
+
+Following the fitting, parameters are estimated based on a certain chunk of the MCMC chain. We take a multiple of
+the autocorrelation time (default: 2) as burn-in, and thin by a multiple of the autocorrelation time (default: 0.5).
+This ensures the points are independent and the walkers have settled in. You can check this is sensible by looking
+at the diagnostic plots we provide functions to produce.
+
+
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,6 +10,7 @@
    :caption: Documentation
 
    install
+   fitting_philosophy
    advanced_topics
    tutorials/single_spectra_fitting
    tutorials/cube_fitting

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -19,5 +19,5 @@ wizardry in a fully automated, Bayesian way so you can turn your spectra into sc
 McFine uses an iterative approach, fitting and comparing increasingly complex models until it deems them sufficiently
 complicated. It does this through the Bayesian and Akaike Information Criterion, and specifically the change in these
 metrics between models. If given a data cube, it can also use the neighbouring information to attempt a better fit.
-For more details about the philosophy and maths of McFine, have a read of Williams & Watkins (2024). It's quite
-short!
+For more details about the philosophy and maths of McFine, have a read of Williams & Watkins (2024), or see
+:doc:`fitting philosophy <fitting_philosophy>`. They're both quite short!

--- a/mcfine/plotting.py
+++ b/mcfine/plotting.py
@@ -102,10 +102,10 @@ class HyperfinePlotter(HyperfineFitter):
             sampler = fit_dict["sampler"]
 
             if n_comp == 0:
-                return
-            samples = sampler.get_chain()
+                return True
+
             self.step(
-                samples,
+                sampler,
                 plot_name,
                 n_comp=n_comp,
             )
@@ -155,6 +155,8 @@ class HyperfinePlotter(HyperfineFitter):
                     )
                 )
 
+        return True
+
     def parallel_step(
         self,
         ij,
@@ -183,17 +185,18 @@ class HyperfinePlotter(HyperfineFitter):
             return False
         sampler = fit_dict["sampler"]
 
-        samples = sampler.get_chain()
         cube_plot_name = f"{plot_name}_{i}_{j}"
         self.step(
-            samples,
+            sampler,
             plot_name=cube_plot_name,
             n_comp=n_comp_pix,
         )
 
+        return True
+
     def step(
         self,
-        samples,
+        sampler,
         plot_name="step_plot",
         n_comp=1,
     ):
@@ -205,6 +208,13 @@ class HyperfinePlotter(HyperfineFitter):
             table="plotting",
             key="file_exts",
         )
+
+        # Get samples from the chain
+        samples = sampler.get_chain()
+
+        # And get the nominal "burn-in" range to put on the
+        # plot
+        burn_in, _ = self.get_burn_in_thin(sampler)
 
         # Load up the labels
         labels = []
@@ -239,6 +249,12 @@ class HyperfinePlotter(HyperfineFitter):
                 ax.plot(samples[:, :, ax_i], c=c, alpha=0.3)
                 ax.set_xlim(0, len(samples))
 
+                ax.axvline(
+                    burn_in,
+                    color="k",
+                    linestyle="--",
+                )
+
                 plt.text(
                     0.05,
                     0.9,
@@ -265,6 +281,8 @@ class HyperfinePlotter(HyperfineFitter):
             )
 
         plt.close()
+
+        return True
 
     def plot_corner(
         self,

--- a/mcfine/toml/config_defaults.toml
+++ b/mcfine/toml/config_defaults.toml
@@ -48,13 +48,15 @@ delta_bic_cutoff = 10
 delta_aic_cutoff = 10
 emcee_run_method = "fixed"
 n_walkers = 100
+n_initialisation = 2
+n_initialisation_steps = 200
 n_steps = 1000
-
-# Specifically for the adaptive fitting
-convergence_factor = 100
-tau_change = 0.01
 thin = 0.5
 burn_in = 2
+
+# Specifically for the adaptive fitting
+convergence_factor = 10
+tau_change = 0.01
 max_steps = 100000
 
 [create_fit_cube]


### PR DESCRIPTION
- Add emcee initialisations, which are important to get the walkers to settle
- Added n_initialisation (default 2) and n_initialisation_steps (default 200) as parameters to control this
- Throughout, all samplers now have burn-in and thin based on autocorrelation times
- Changed default autocorrelation length convergence factor from 100 to 10
- Step plot now shows the nominal burn-in range
- Included docs page on how the fitting is done
